### PR TITLE
chore(home): 🔧 機能していない訪問カウンタを削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules
 .env
 .env.*
 .vercel
-.data/kv/pageVisits
+.data
 tmp
 *-tmp
 dist

--- a/app/components/content/home/HomeLanding.vue
+++ b/app/components/content/home/HomeLanding.vue
@@ -2,11 +2,6 @@
 import type { BlogPostPreview } from '~~/types'
 import { computed } from 'vue'
 
-const { data: pageVisits } = useLazyFetch(() => `/api/kv`)
-function refreshPage() {
-  window.location.reload()
-}
-
 function normalizeEntry<T extends BlogPostPreview>(entry?: Partial<T> | null): T | null {
   if (!entry)
     return null
@@ -145,19 +140,6 @@ useSchemaOrg([
         section="blog"
         variant="blog"
       />
-    </section>
-    <section aria-labelledby="vercel-kv" class="home-section mt-16">
-      <div class="flex flex-col items-center gap-6">
-        <button
-          @click="refreshPage()"
-          class="px-6 py-3 font-bold !text-white bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 dark:from-blue-500 dark:to-blue-600 dark:hover:from-blue-600 dark:hover:to-blue-700 rounded-lg shadow-md hover:shadow-lg transition-all duration-200 hover:-translate-y-0.5"
-        >
-          Refresh page
-        </button>
-        <div class="text-5xl font-bold text-gray-900 dark:text-gray-100">
-          {{ pageVisits?.pageVisits }}
-        </div>
-      </div>
     </section>
     <LazyScrollToTop />
   </section>

--- a/server/api/kv.get.ts
+++ b/server/api/kv.get.ts
@@ -1,9 +1,0 @@
-export default defineEventHandler(async (_event) => {
-  const dataStorage = useStorage('data')
-  const pageVisits = (await dataStorage.getItem('pageVisits')) as number
-  const updatePageVisits = pageVisits + 1
-  await dataStorage.setItem('pageVisits', updatePageVisits)
-  return {
-    pageVisits: updatePageVisits,
-  }
-})


### PR DESCRIPTION
## 概要

トップページ下部の訪問カウンタ（`{{ pageVisits?.pageVisits }}`）は本番で完全に機能していなかったため、機能ごと削除します。

## 調査結果

### ① API が本番で常に 500

```
$ curl https://nuxtation.vercel.app/api/kv   # 5回とも
{"error":true,"statusCode":500,"statusMessage":"Server Error"}
```

### ② 表示値はビルド時の焼き付き

`/` は `prerender.crawlLinks: true` によりプリレンダされるため、SSR 時点の値が静的 HTML に埋め込まれます。

| | 焼き付いた値 |
|---|---|
| 本番（3回取得しても不変） | **`1`** |
| ローカルビルド | **`109`**（`.data/kv/pageVisits` の値） |

「Refresh page」ボタンは静的 HTML を読み直すだけなので、数値は永遠に変わりません。

### ③ 根本原因

`nuxt.config.ts` にあった storage 設定が失われていました。

```diff
# 785497a "update Nuxt to v3.8.0 ann add Vercel KV" で有効化されていた
+   storage: {
+     data: { driver: 'vercelKV'}
```

現在は `cache:nuxt:payload` の設定しかなく、ビルド出力では Nitro 既定のファイルシステムドライバにマウントされています。

```js
storage.mount('data', unstorage_47drivers_47fs_45lite({"driver":"fsLite","base":"./.data/kv"}))
```

Vercel の関数は `/tmp` 以外が読み取り専用のため `setItem` が落ち、500 になります。dev では書き込めるうえプリレンダもビルド環境で成功するため、**気づけないタイプの退行**でした。

## 変更内容

| ファイル | 内容 |
|---|---|
| `app/components/content/home/HomeLanding.vue` | `vercel-kv` セクション / `useLazyFetch` / `refreshPage()` を削除 |
| `server/api/kv.get.ts` | 削除 |
| `.gitignore` | `.data/kv/pageVisits` → `.data` |

`useStorage()` の利用箇所は他になくなったため、`nuxt.config.ts` の変更は不要です。

### `.gitignore` を `.data` に変えた理由

Nuxt Content の `.data/content/contents.sqlite`（5.9MB）が、**リポジトリの `.gitignore` では守られておらず、グローバル `~/.gitignore_global` の `*.sqlite` だけに依存**していました。他の環境では誤コミットされうる状態です。docustation は既に `.data` を指定しているので揃えました。

## Vercel KV での復旧を選ばなかった理由

復旧自体は可能でしたが（`unstorage@1.17.5` に `vercel-kv` / `upstash` ドライバは現存）、KV ストアの作成・環境変数設定・新規依存の追加が必要になります。訪問カウンタ自体が現在のサイトに不要と判断したため、削除を選びました。

## 検証

- [x] `pnpm lint` — exit 0
- [x] `pnpm build` — exit 0
- [x] ビルド出力 `.vercel/output/static/index.html` から `vercel-kv` / `Refresh page` が消えたことを確認（grep 一致 0件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)