### PR TITLE
fix(css): 🐛 kiso.css をレイヤーに入れ lang="ja" を実際に出力させる

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,4 +1,20 @@
 export default defineAppConfig({
+  docus: {
+    /*
+     * <html lang> の供給元。
+     *
+     * nuxt.config.ts の app.head.htmlAttrs.lang は、Docus 自身の app.vue が
+     * 後から useHead({ htmlAttrs: { lang } }) で上書きするため効かない。
+     * その lang は docus/app/plugins/i18n.ts が `appConfig.docus.locale`
+     * （既定 'en'）から解決しているので、ここで指定する必要がある。
+     *
+     * これを 'ja' にしないと kiso.css の `:lang(ja)` ルール
+     * （日本語の em を太字にする・i/cite/dfn のイタリックを解除する等）が
+     * 一切適用されず、逆に英語向けの `:lang(en) { text-wrap: pretty }` が
+     * 日本語本文に当たってしまう。
+     */
+    locale: 'ja',
+  },
   seo: {
     title: 'Nuxtation',
     description: 'Nuxt 4で構築したブログサイトです。',

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -8,6 +8,21 @@
  * 先頭で済ませているため、ここでは書かない（重複 import になる）。
  */
 
+/*
+ * 日本語向けリセット（kiso.css）
+ *
+ * 必ず `layer(base)` を付けて読み込む。nuxt.config.ts の `css: []` から
+ * 読み込むとレイヤー外になり、CSS カスケードの判定順（起点 → レイヤー →
+ * 詳細度）により *レイヤー外が全レイヤーに勝つ* ため、`:where()` で詳細度を
+ * 0 にしていても Tailwind の `@layer utilities` を打ち消してしまう。
+ * 実際に p の `my-4` や ul の `ps-6 list-disc` が無効化されていた。
+ *
+ * base に入れると Tailwind の preflight より後・utilities より前に位置し、
+ * リセットとしての役割（text-autospace / text-spacing-trim / line-break 等の
+ * 日本語組版設定を含む）はそのまま保たれる。
+ */
+@import 'kiso.css/kiso.css' layer(base);
+
 /* デザイントークン（@theme / Tailwind v4） */
 @import './tailwind.css';
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -136,7 +136,9 @@ export default defineNuxtConfig({
   },
 
   css: [
-    '@@/node_modules/kiso.css/kiso.css',
+    // kiso.css はここでは読み込まない。ここから読むとレイヤー外になり
+    // Tailwind の @layer utilities を打ち消すため、
+    // app/assets/css/main.css で `layer(base)` 付きで import している。
     // 'v-network-graph/lib/style.css', // 削除: 未使用
     '@shikijs/twoslash/style-rich.css', // twoslash のホバーツールチップ用スタイル
   ],
@@ -162,6 +164,12 @@ export default defineNuxtConfig({
     url: 'https://nuxtation.vercel.app',
     description: 'Nuxt 4で構築したブログサイト',
     language: 'ja',
+    // <html lang> の実際の供給元。nuxt-seo-utils の applyDefaults が
+    // `siteConfig.currentLocale || siteConfig.defaultLocale || 'en'` で
+    // htmlAttrs.lang を決めており、上の `language` は参照されない。
+    // これを入れないと日本語サイトなのに lang="en" が出力され、
+    // kiso.css の `:lang(ja)` ルールが一切効かなくなる。
+    defaultLocale: 'ja',
     twitter: '@muraie_jin',
     trailingSlash: false,
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "check:contrast": "npx tsx scripts/check-contrast.ts",
+    "check:css-layers": "npx tsx scripts/check-css-layers.ts",
     "release:patch": "changelogen --release --patch",
     "release:minor": "changelogen --release --minor",
     "release:major": "changelogen --release --major",

--- a/scripts/check-css-layers.ts
+++ b/scripts/check-css-layers.ts
@@ -1,0 +1,253 @@
+/**
+ * CSS カスケードレイヤーの事故検知
+ *
+ * 背景:
+ *   CSS の判定順は 起点 → **レイヤー** → 詳細度 の順で、通常宣言では
+ *   「レイヤー外」が全レイヤーに勝つ。つまり `:where()` で詳細度を 0 に
+ *   したリセット CSS でも、レイヤー外に置かれていれば Tailwind の
+ *   `@layer utilities` を打ち消してしまう。
+ *
+ *   実際に kiso.css を nuxt.config.ts の `css: []` から読み込んでいた時期、
+ *   p の `my-4` や ul の `ps-6 list-disc` が無効化されていた（見た目では
+ *   気づきにくく、要素ごとに計算値を測って初めて判明した）。
+ *
+ * このスクリプトの役割:
+ *   ビルド成果物のインライン CSS を解析し、レイヤー外に「要素セレクタへの
+ *   リセット」が紛れ込んでいないかを検査する。実ブラウザは使わないので
+ *   CI でも動く。
+ *
+ * 使い方:
+ *   pnpm build && pnpm check:css-layers
+ *   pnpm check:css-layers --strict   # 問題があれば exit 1
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+/** ビルド成果物の探索先（先に見つかったものを使う） */
+const OUTPUT_DIRS = ['.output/public', '.vercel/output/static', 'dist']
+
+/**
+ * レイヤー外にあると Tailwind ユーティリティを潰す可能性が高いプロパティ。
+ * リセット CSS が「UA スタイルの打ち消し」目的で触りがちなものを挙げている。
+ */
+const RISKY_PROPERTIES = [
+  'margin',
+  'margin-block',
+  'margin-inline',
+  'margin-top',
+  'margin-bottom',
+  'padding',
+  'padding-block',
+  'padding-inline',
+  'padding-inline-start',
+  'list-style',
+  'list-style-type',
+  'color',
+  'background-color',
+  'font',
+  'font-size',
+  'font-weight',
+  'font-style',
+  'text-align',
+  'text-decoration',
+  'text-decoration-line',
+  'border',
+  'border-width',
+  'border-color',
+  'border-radius',
+]
+
+/** キーフレームのオフセット（`0%` / `from` / `to`）はセレクタではない */
+function isKeyframeOffset(selector: string): boolean {
+  return selector.split(',').every(s => /^\s*(?:from|to|-?[\d.]+%)\s*$/.test(s))
+}
+
+/** 要素セレクタ（クラスや ID を含まない）にマッチするか */
+function isElementSelector(selector: string): boolean {
+  if (isKeyframeOffset(selector))
+    return false
+  // :where(...) / :is(...) の中身も対象にする
+  const inner = selector.replace(/:(?:where|is)\(([^()]*)\)/g, '$1')
+  // クラス・ID・属性セレクタを含むものはコンポーネント固有とみなし対象外
+  if (/[.#[]/.test(inner))
+    return false
+  return /[a-z]/i.test(inner)
+}
+
+function findHtmlFiles(dir: string, acc: string[] = [], depth = 0): string[] {
+  if (depth > 4)
+    return acc
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  }
+  catch {
+    return acc
+  }
+  for (const e of entries) {
+    const p = join(dir, e)
+    let st
+    try {
+      st = statSync(p)
+    }
+    catch {
+      continue
+    }
+    if (st.isDirectory())
+      findHtmlFiles(p, acc, depth + 1)
+    else if (e.endsWith('.html'))
+      acc.push(p)
+  }
+  return acc
+}
+
+/** <style> の中身を取り出す */
+function extractStyles(html: string): string[] {
+  return [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(m => m[1] ?? '')
+}
+
+/**
+ * スタイルシート文字列から検査対象外のブロックを取り除く。
+ *
+ * - `@layer { ... }`  : レイヤー内はそもそも問題にならない
+ * - `@keyframes { ... }` : `0%` / `from` / `to` はセレクタではないので誤検知になる
+ */
+function stripBlocks(css: string, atRules: string[]): string {
+  let out = ''
+  let i = 0
+  while (i < css.length) {
+    // 最も手前に現れる対象 at-rule を探す
+    let at = -1
+    for (const rule of atRules) {
+      const p = css.indexOf(rule, i)
+      if (p !== -1 && (at === -1 || p < at))
+        at = p
+    }
+    if (at === -1) {
+      out += css.slice(i)
+      break
+    }
+    out += css.slice(i, at)
+    // `@layer name;` のような宣言のみの形はそのまま飛ばす
+    const brace = css.indexOf('{', at)
+    const semi = css.indexOf(';', at)
+    if (brace === -1 || (semi !== -1 && semi < brace)) {
+      i = (semi === -1 ? css.length : semi + 1)
+      continue
+    }
+    // 対応する } まで飛ばす
+    let depth = 0
+    let j = brace
+    for (; j < css.length; j++) {
+      if (css[j] === '{') {
+        depth++
+      }
+      else if (css[j] === '}') {
+        depth--
+        if (depth === 0) {
+          j++
+          break
+        }
+      }
+    }
+    i = j
+  }
+  return out
+}
+
+/** ルールを大雑把に分解する（@media 等のネストは中身を再帰的に見る） */
+function* iterateRules(css: string): Generator<{ selector: string, body: string }> {
+  const re = /([^{}]+)\{([^{}]*)\}/g
+  for (const m of css.matchAll(re)) {
+    const selector = (m[1] ?? '').trim()
+    const body = m[2] ?? ''
+    if (selector.startsWith('@'))
+      continue
+    if (!selector)
+      continue
+    yield { selector, body }
+  }
+}
+
+interface Finding {
+  file: string
+  selector: string
+  props: string[]
+}
+
+function main() {
+  const strict = process.argv.includes('--strict')
+
+  const dir = OUTPUT_DIRS.find((d) => {
+    try {
+      return statSync(d).isDirectory()
+    }
+    catch {
+      return false
+    }
+  })
+  if (!dir) {
+    console.error(`ビルド成果物が見つかりません。次のいずれかを用意してください: ${OUTPUT_DIRS.join(', ')}`)
+    console.error('先に `pnpm build` を実行してください。')
+    process.exit(strict ? 1 : 0)
+  }
+
+  const files = findHtmlFiles(dir).slice(0, 40)
+  if (files.length === 0) {
+    console.error(`${dir} に HTML が見つかりませんでした。`)
+    process.exit(strict ? 1 : 0)
+  }
+
+  const findings: Finding[] = []
+  const seen = new Set<string>()
+
+  for (const file of files) {
+    const html = readFileSync(file, 'utf8')
+    for (const style of extractStyles(html)) {
+      const unlayered = stripBlocks(style, ['@layer', '@keyframes', '@-webkit-keyframes'])
+      for (const { selector, body } of iterateRules(unlayered)) {
+        if (!isElementSelector(selector))
+          continue
+        const props = RISKY_PROPERTIES.filter(p =>
+          new RegExp(`(^|[;{\\s])${p}\\s*:`).test(body),
+        )
+        if (props.length === 0)
+          continue
+        const key = `${selector}|${props.join(',')}`
+        if (seen.has(key))
+          continue
+        seen.add(key)
+        findings.push({ file: file.replace(`${dir}/`, ''), selector, props })
+      }
+    }
+  }
+
+  console.log('CSS カスケードレイヤー検査')
+  console.log(`  対象: ${dir}（HTML ${files.length} ファイル）`)
+  console.log('─'.repeat(76))
+
+  if (findings.length === 0) {
+    console.log('\n✅ レイヤー外に要素セレクタのリセットは見つかりませんでした。')
+    console.log('   Tailwind の @layer utilities は打ち消されていません。\n')
+    return
+  }
+
+  console.log('\n⚠️  レイヤー外に要素セレクタのリセットがあります。')
+  console.log('   レイヤー外は全レイヤーに勝つため、詳細度 0 の :where() でも')
+  console.log('   Tailwind の @layer utilities を打ち消します。\n')
+  for (const f of findings) {
+    console.log(`  セレクタ : ${f.selector.slice(0, 70)}`)
+    console.log(`  プロパティ: ${f.props.join(', ')}`)
+    console.log(`  検出元   : ${f.file}`)
+    console.log()
+  }
+  console.log('対処: 該当の CSS を `@import "..." layer(base);` で読み込むか、')
+  console.log('      `@layer base { ... }` で包んでください。\n')
+
+  if (strict)
+    process.exit(1)
+}
+
+main()


### PR DESCRIPTION
## 概要

kiso.css が Tailwind のユーティリティを打ち消していた問題と、日本語サイトなのに `lang="en"` が出力され kiso.css の `:lang(ja)` ルールが一切効いていなかった問題を修正します。すべて実ブラウザ（Chrome）の計算値で確認しました。

## 問題① kiso.css がレイヤー外だった

`nuxt.config.ts` の `css: []` から読み込むと**レイヤー外**になります。CSS の判定順は 起点 → **レイヤー** → 詳細度 で、通常宣言では *レイヤー外が全レイヤーに勝つ*ため、`:where()` で詳細度を 0 にしていても Tailwind の `@layer utilities` を打ち消していました。

同じクラスでタグだけ変えた対照実験（`--spacing` は `.25rem` で正常）：

| 要素 | クラス | 結果 |
|---|---|---|
| `div.my-4` | kiso のリセット対象外 | margin **16px** ✅ |
| `p.my-4` | kiso のリセット対象 | margin **0px** ❌ |
| `div.ps-6` | 対象外 | padding **24px** ✅ |
| `ul.ps-6.list-disc` | 対象 | padding **0px**・マーカー **`""`** ❌ |

**本文の段落余白と箇条書きのインデント・行頭記号が消えていました。** 影響は `p / ul / ol / dl / blockquote / figure / pre / address / menu / h2〜h6 / a / table / th / caption / フォーム要素` に及びます。

### 修正

`app/assets/css/main.css` で `@import 'kiso.css/kiso.css' layer(base);` として読み込みます。Tailwind の preflight より後・utilities より前に位置するため、リセットとしての役割はそのまま保たれます。

## 問題② `lang="en"` が出力されていた

`nuxt.config.ts` の `app.head.htmlAttrs.lang` も `app/app.vue` の `useHead` も `'ja'` を指定していましたが、`nuxt-seo-utils` の `applyDefaults` が実際の供給元でした。

```js
// nuxt-seo-utils/dist/runtime/app/logic/applyDefaults.js
const locale = toValue(siteConfig.currentLocale) || toValue(siteConfig.defaultLocale) || "en"
...
useHead({ htmlAttrs: { lang: resolveCurrentLocale } }, { tagPriority: 'low' })
```

既存の `site.language: 'ja'` は**別キーで参照されていません**。

### 修正

- `site.defaultLocale: 'ja'` を追加
- あわせて `app.config.ts` に `docus.locale: 'ja'` を設定（`docus/app/plugins/i18n.ts` が `appConfig.docus.locale` から解決しており、Docus の UI 文言が日本語になります）

## 修正後の実測

| 項目 | 修正前 | 修正後 |
|---|---|---|
| `<html lang>` | `en` ❌ | **`ja`** ✅ |
| `p.my-4` margin | 0px ❌ | **16px** ✅ |
| `ul.ps-6.list-disc` | 0px・`""` ❌ | **24px・disc** ✅ |
| `ol.ps-6.list-decimal` | 0px・`""` ❌ | **24px・decimal** ✅ |
| `blockquote.my-6.ps-4` | 0px ❌ | **24px・16px** ✅ |
| `em`（`:lang(ja)`） | イタリックのまま ❌ | **normal / 700** ✅ |
| `text-autospace` | normal ✅ | **normal** ✅ 維持 |
| `text-spacing-trim` | trim-start ✅ | **trim-start** ✅ 維持 |
| `line-break` | strict ✅ | **strict** ✅ 維持 |

**副作用だけ消えて、日本語組版の効果はそのまま残っています。**

## 再発防止

`scripts/check-css-layers.ts` を追加しました（`pnpm check:css-layers`）。ビルド成果物のインライン CSS を解析し、レイヤー外に要素セレクタのリセットが紛れ込んでいないか検査します。実ブラウザ不要なので CI でも動きます。

```
$ pnpm check:css-layers --strict
✅ レイヤー外に要素セレクタのリセットは見つかりませんでした。
   Tailwind の @layer utilities は打ち消されていません。
```

## 検証

- [x] `pnpm lint` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm check:contrast --strict` — 未定義トークン 0 / 明るすぎる背景 0 / コントラスト要確認 0
- [x] `pnpm check:css-layers --strict` — exit 0
- [x] 実ブラウザ（Chrome）でビルド成果物の計算値を確認

> **レビュー観点**: 段落・リスト・引用の余白が復活するため、**レイアウトが意図的に変わります**。主要ページの見た目をご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)