### PR TITLE
fix(css): 🐛 kiso.css のフォーム要素ボーダー既定値を外しタブの枠を解消

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -40,3 +40,28 @@
 
 /* トランジション設定 */
 @import './transitions.css';
+
+/*
+ * kiso.css のフォーム要素ボーダー既定値を Tailwind の既定に戻す。
+ * （`@import` は全て上に書き切る必要があるため、ここに置いている）
+ *
+ * kiso.css は「未装飾のフォーム要素でも判別できるように」という意図で
+ * `:where(button, input, select, textarea)` に border-width: 1px を入れる。
+ * 一方 Nuxt UI / Tailwind は preflight の `border: 0 solid` を前提に、
+ * 枠が必要な箇所だけ `border-*` ユーティリティで足す設計になっている。
+ * この2つの前提が衝突し、クラスにボーダー指定を持たない Nuxt UI の部品
+ * （コードグループのタブ、アイコンボタン等）に意図しない枠が出ていた。
+ *
+ * 実測（記事ページ1枚）: フォーム要素 29 個のうち 20 個が意図しない枠を
+ * 持ち、kiso の既定に依存している要素は 0 個だった。よって既定値のみ外す。
+ * kiso の他のリセットと日本語組版の設定はそのまま維持される。
+ *
+ * base レイヤー内で kiso より後に書くことで上書きし、`border-*`
+ * ユーティリティ（utilities レイヤー）は従来どおり優先される。
+ */
+@layer base {
+  :where(button, input, select, textarea),
+  ::file-selector-button {
+    border-width: 0;
+  }
+}


### PR DESCRIPTION
## 概要

コードグループのタブが1つずつ枠で囲まれ、タブに見えない問題を修正します。

（ご報告のスクリーンショットの症状。`@layer` 移動より前から存在した既存の問題でした）

## 原因

kiso.css は「未装飾のフォーム要素でも判別できるように」という意図で、フォーム要素に既定のボーダーを入れます。

```css
/* kiso.css */
:where(button, input, select, textarea), ::file-selector-button {
  border-width: 1px;
  border-style: solid;
}
```

一方 Nuxt UI / Tailwind は preflight の `border: 0 solid` を前提に、**枠が必要な箇所だけ `border-*` ユーティリティで足す**設計です。この2つの前提が正面衝突し、クラスにボーダー指定を持たない Nuxt UI の部品に意図しない枠が出ていました。

`role="tab"` だけの問題ではありません。実ブラウザで計測したところ：

| | 記事ページ1枚あたり |
|---|---|
| フォーム要素の総数 | 29 |
| **意図しない枠を持つ要素** | **20** |
| kiso の既定に依存している要素 | **0** |

依存がゼロなので、`[role=tab]` だけを潰すのではなく既定値そのものを Tailwind の既定に戻します。

## 変更内容

`app/assets/css/main.css` の末尾に、`base` レイヤー内で kiso より後に来る上書きを追加：

```css
@layer base {
  :where(button, input, select, textarea),
  ::file-selector-button {
    border-width: 0;
  }
}
```

- kiso の他のリセットと**日本語組版の設定は維持**されます（`text-autospace` / `text-spacing-trim` / `line-break`）
- `border-*` ユーティリティは utilities レイヤーなので**従来どおり優先**されます

## 修正後の実測

| 項目 | 修正前 | 修正後 |
|---|---|---|
| 意図しない枠を持つ要素 | 20 ❌ | **0** ✅ |
| タブの `border-width` | 1px ❌ | **0px** ✅ |
| アクティブタブの区別 | — | 文字色（Docus 本来の設計）✅ |
| `border-2` ユーティリティ | — | **2px** ✅ 正常動作 |

## 検証

- [x] `pnpm lint` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm check:contrast --strict` — 0 件
- [x] `pnpm check:css-layers --strict` — exit 0
- [x] 実ブラウザ（Chrome）でビルド成果物の計算値とスクリーンショットを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)