### PR TITLE
ci: 🔧 CSSコントラストとカスケードレイヤーの検査をCIに追加

### DIFF
--- a/.github/workflows/css-contrast.yml
+++ b/.github/workflows/css-contrast.yml
@@ -1,0 +1,33 @@
+# デザイントークンのコントラスト検査
+#
+# scripts/check-contrast.ts は app/assets/css/tailwind.css と app/ 配下を
+# 読むだけでビルド成果物を必要としないため、PR ごとに軽量に回せる。
+# (ビルドが要る check:css-layers は ssg-check.yml のビルド後に相乗りさせている)
+#
+# 検査内容:
+#   - 未定義のカラートークン参照 (var(--color-xxx) の定義漏れ)
+#   - グラデーション等で白文字を載せる背景が明るすぎないか
+#   - 前景/背景ペアの WCAG AA (通常 4.5:1 / 大きい文字・非テキスト 3:1)
+name: CSS contrast check
+on:
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  group: css-contrast-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  contrast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4 # versionはpackage.jsonのpackageManagerを使用
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+      # postinstall の nuxi prepare は2分以上かかるがこの検査には不要なため
+      # --ignore-scripts で省く。tsx の実行に必要な依存は入る。
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Check color contrast (WCAG AA)
+        run: pnpm check:contrast --strict

--- a/.github/workflows/ssg-check.yml
+++ b/.github/workflows/ssg-check.yml
@@ -32,3 +32,8 @@ jobs:
           echo "HTML files: $html_count"
           # 全ページ欠落の検知が目的なので、平常値(約34)より大幅に低い閾値にする
           [ "$html_count" -ge 15 ] || { echo "::error::HTML出力が少なすぎます ($html_count < 15)。prerenderの失敗を確認してください"; exit 1; }
+      # ビルド成果物のインラインCSSを解析するため、必ず build の後に実行する。
+      # レイヤー外に置かれたリセットCSSがTailwindの@layer utilitiesを打ち消す
+      # 事故を検知する(kiso.cssをcss:[]から読んでいた時期に実際に発生した)。
+      - name: Check CSS cascade layers
+        run: pnpm check:css-layers --strict

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "stylelint": "^17.14.1",
     "tailwindcss": "^4.3.3",
     "ts-node": "^10.9.2",
+    "tsx": "^4.22.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
     "unist-util-visit": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@25.9.5)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## 概要

`pnpm check:contrast --strict` と `pnpm check:css-layers --strict` を GitHub Actions に組み込みます。

## 設計

2つのスクリプトは必要なものが違うので、走らせ方を分けました。

| チェック | ビルド成果物 | 配置 | トリガー |
|---|---|---|---|
| `check:contrast` | **不要**（`tailwind.css` と `app/` を読むだけ） | **新規** `css-contrast.yml` | `pull_request` + 手動 |
| `check:css-layers` | **必須**（インライン CSS を解析） | 既存 `ssg-check.yml` にステップ追加 | 既存のまま変更なし |

`check:css-layers` は既存のビルドジョブに相乗りするため**追加コストはほぼゼロ**です。`check:contrast` 側は postinstall の `nuxi prepare`（2分以上）が不要なので `--ignore-scripts` で省いています。

実測: `install 1分7秒` + 検査。

## `tsx` を devDependencies に追加した理由

CI 環境を再現したクリーンなクローンで検証したところ、**`npx tsx` が `command not found`（exit 127）で失敗しました。**

```
$ pnpm check:contrast --strict
sh: tsx: command not found
[ELIFECYCLE] Command failed with exit code 127.
```

原因は `tsx` が依存として宣言されておらず、**vite / importx の推移依存としてたまたま `node_modules` に存在していただけ**だったことです。直接依存ではないため `node_modules/.bin` にリンクされず、ローカルでは動くが新規チェックアウトでは落ちる状態でした。

これは CI 以前の潜在的な問題で、`check:contrast` と `check:css-layers` の**両方**が影響を受けます。実際に依存している `tsx` を明示的に宣言しました。パッケージ自体は既に依存ツリーにあるため、インストール量は増えません。

## 検証

- [x] クリーンなクローンで `pnpm install --frozen-lockfile --ignore-scripts` → `pnpm check:contrast --strict` が **exit 0** で通ることを確認
- [x] `tsx` が `node_modules/.bin/tsx` にリンクされることを確認
- [x] `pnpm lint` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)