### PR TITLE
fix(deps): 🔒 Snyk 指摘の推移的依存5件を修正版へ引き上げる

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,21 +10,22 @@ overrides:
   basic-ftp@^5.0.0: ^5.3.1
   body-parser@^1.0.0: ^1.20.6
   body-parser@^2.0.0: ^2.3.0
-  brace-expansion@^1.0.0: ^1.1.16
-  brace-expansion@^2.0.0: ^2.1.2
-  brace-expansion@^5.0.0: ^5.0.8
+  brace-expansion@^1.0.0: ^1.1.18
+  brace-expansion@^2.0.0: ^2.1.4
+  brace-expansion@^5.0.0: ^5.0.9
   esbuild: ^0.28.1
   express-rate-limit@^8.0.0: ^8.2.2
-  fast-uri@^3.0.0: ^3.1.4
+  fast-uri@^3.0.0: ^3.1.5
   handlebars: ^4.7.9
   hono@^4.0.0: ^4.12.27
   ip-address@^10.0.0: ^10.1.1
   js-cookie@^3.0.0: ^3.0.6
-  js-yaml@^3.0.0: ^3.15.0
+  js-yaml@^3.0.0: ^3.15.1
   launch-editor@^2.0.0: ^2.14.1
   linkify-it@^5.0.0: ^5.0.2
   lodash-es@^4.0.0: ^4.18.0
   markdown-it@^14.0.0: ^14.2.0
+  nanoid@^3.0.0: ^3.3.18
   path-to-regexp@^0.1.0: ^0.1.13
   path-to-regexp@^8.0.0: ^8.4.0
   postcss: ^8.5.23
@@ -33,19 +34,19 @@ overrides:
   sharp: ^0.35.3
   shell-quote@^1.0.0: ^1.9.0
   simple-git@^3.0.0: ^3.36.0
-  socket.io-parser@^4.0.0: ^4.2.6
+  socket.io-parser@^4.0.0: ^4.2.7
   svgo@^4.0.0: ^4.0.2
   tar@^7.0.0: ^7.5.21
   tmp: ^0.2.7
   unconfig: 0.4.1
   undici@^6.0.0: ^6.27.0
   uuid: ^11.1.1
-  vite@^7.0.0: ^8.1.5
   vite-dev-rpc: ^2.0.0
   vite-hot-client: ^2.2.0
   vite-plugin-inspect: ^11.4.1
   vite-plugin-pwa: ^1.3.0
   vite-plugin-vue-tracer: ^1.4.0
+  vite@^7.0.0: ^8.1.5
   ws@7: ^7.5.13
   ws@8: ^8.21.1
   zod: ^4.4.3
@@ -5606,14 +5607,14 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -6984,8 +6985,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -7975,12 +7976,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.2.0:
@@ -8679,8 +8680,8 @@ packages:
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12039,7 +12040,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -13998,7 +13999,7 @@ snapshots:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       isomorphic-fetch: 3.0.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       lighthouse: 12.6.1(supports-color@10.2.2)
       tree-kill: 1.2.2
     transitivePeerDependencies:
@@ -16263,7 +16264,7 @@ snapshots:
   '@rollup/plugin-yaml@4.1.2(rollup@4.60.4)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.60.4)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       tosource: 2.0.0-alpha.3
     optionalDependencies:
       rollup: 4.60.4
@@ -17785,14 +17786,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -18078,16 +18079,16 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -18414,7 +18415,7 @@ snapshots:
     dependencies:
       entities: 8.0.0
       htmlparser2: 12.0.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       markdown-exit: 1.0.0-beta.9
     optionalDependencies:
       shiki: 4.3.1
@@ -18530,7 +18531,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -19853,7 +19854,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -21043,12 +21044,12 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -21898,19 +21899,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -21974,7 +21975,7 @@ snapshots:
 
   mute-stream@0.0.7: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanotar@0.3.0: {}
 
@@ -23770,7 +23771,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,22 +68,27 @@ overrides:
   # brace-expansion の連続する空 {} グループによる指数時間展開 DoS。
   # メジャーごとにレンジを区切って各系統の最新へ引き上げる。
   #
-  # 一律 5.0.8 に統一してはいけない。v5 は default export を廃止しており、
-  # minimatch 5.x/9.x の `import expand from 'brace-expansion'` が
-  # 「does not provide an export named 'default'」で落ちる(実測)。
-  # 最新のアドバイザリ(<=5.0.7)は 1系/2系も対象とするが、両系統の最新は
-  # 1.1.16 / 2.1.2 で修正版が出ていないため、ここは上流の対応待ちとする。
-  brace-expansion@^1.0.0: ^1.1.16
-  brace-expansion@^2.0.0: ^2.1.2
-  brace-expansion@^5.0.0: ^5.0.8
+  # 一律 5.0.9 に統一してはいけない。v5 は呼び出し規約を変えており、
+  # 下位系統を引く minimatch がどちらの入口からも壊れる(いずれも実測):
+  #   minimatch 9.x (ESM, `import expand from 'brace-expansion'`)
+  #     → 「does not provide an export named 'default'」で落ちる
+  #   minimatch 3.x/5.x (CJS, `require('brace-expansion')`)
+  #     → 戻り値が object になり関数として呼べない({ expand, EXPANSION_MAX,
+  #       EXPANSION_MAX_LENGTH })。呼ぶなら `.expand(...)` が要る
+  #
+  # 2026-08-09: 1系/2系にも修正版が出たので上流の対応待ちを解消した
+  # (以前は 1.1.16 / 2.1.2 が各系統の最新で、修正版が無かった)。
+  brace-expansion@^1.0.0: ^1.1.18
+  brace-expansion@^2.0.0: ^2.1.4
+  brace-expansion@^5.0.0: ^5.0.9
   # esbuild: 開発サーバへの任意リクエスト送信(<=0.24.2)と Windows での
   # 任意ファイル読み取り(0.27.3〜0.28.0)。いずれも開発サーバ限定で本番成果物に
   # 影響はないが、複数系統がツリーに居るため 0.28.1 に統一する。
   esbuild: ^0.28.1
   # express-rate-limit: レート制限の回避
   express-rate-limit@^8.0.0: ^8.2.2
-  # fast-uri: URIパースのReDoS
-  fast-uri@^3.0.0: ^3.1.4
+  # fast-uri: URIパースのReDoS。3.1.5 で Interpretation Conflict も解消
+  fast-uri@^3.0.0: ^3.1.5
   handlebars: ^4.7.9
   # postcss<8.5.16 の Directory Traversal 対応。cssnano 系と @tailwindcss/postcss が
   # 8.5.15 を牽引するため 8.5.23 を強制する。
@@ -94,7 +99,7 @@ overrides:
   # js-cookie: Cookie の取り扱い不備
   js-cookie@^3.0.0: ^3.0.6
   # js-yaml: マージキー連鎖による二次的CPU消費(@lhci/utils が 3系を牽引)
-  js-yaml@^3.0.0: ^3.15.0
+  js-yaml@^3.0.0: ^3.15.1
   # launch-editor: Windows の UNC パス経由の NTLMv2 ハッシュ漏洩(@nuxt/devtools 経由)
   launch-editor@^2.0.0: ^2.14.1
   # linkify-it: リンク検出のReDoS
@@ -103,6 +108,10 @@ overrides:
   lodash-es@^4.0.0: ^4.18.0
   # markdown-it: パースのReDoS
   markdown-it@^14.0.0: ^14.2.0
+  # nanoid: 非整数の size を渡したときの無限ループ。postcss が牽引する。
+  # postcss@8.5.23 は `^3.3.16` を宣言しているので 3系に留める(4系以降を
+  # 強制すれば契約違反になるうえ、CJS の入口が無い — main を持つのは 3系だけ)。
+  nanoid@^3.0.0: ^3.3.18
   # path-to-regexp: パターンのReDoS。0系と8系が同居する
   path-to-regexp@^0.1.0: ^0.1.13
   path-to-regexp@^8.0.0: ^8.4.0
@@ -119,8 +128,9 @@ overrides:
   shell-quote@^1.0.0: ^1.9.0
   # simple-git: コマンド引数の取り扱い不備
   simple-git@^3.0.0: ^3.36.0
-  # socket.io-parser: パース不備
-  socket.io-parser@^4.0.0: ^4.2.6
+  # socket.io-parser: パース不備。4.2.7 で Improper Check for Unusual or
+  # Exceptional Conditions も解消
+  socket.io-parser@^4.0.0: ^4.2.7
   # svgo: SVG 最適化時の不具合
   svgo@^4.0.0: ^4.0.2
   # tar: 展開時のDoS/パス解釈差異(CRITICAL 含む)
@@ -148,7 +158,11 @@ overrides:
   # vitest 4 が動かない（rolldown ベースの vite 8 を前提にしており、rolldown を持たない
   # vite 7 では transform 時に「Missing field `moduleType`」で全 spec が落ちる）。
   # 8系はこのアドバイザリを当然満たすので、8系へ寄せる。
-  # 完了条件は `pnpm peers check` で vite の unmet peer が消えること。
+  #
+  # **完了条件に `pnpm peers check` を使わないこと。** この override は
+  # pnpm-lock.yaml 上の peerDependencies 宣言ごと書き換えるため、非互換な
+  # パッケージも「充足」と表示される。`pnpm check:vite-peers` で上流の宣言と
+  # 突き合わせること（scripts/check-vite-peers.ts の冒頭に経緯あり）。
   vite@^7.0.0: ^8.1.5
   ws@7: ^7.5.13
   # ws CVE-2026-48779 (fragment枯渇によるOOM) 対応。7系は7.5.11でバックポート修正、


### PR DESCRIPTION
Snyk から届いた6通の指摘（2026-08-04〜08-09）に対応します。

## 原因

いずれも **override の固定値が古く、修正版が出た後も旧版に留まっていた**ものです。メール本文の「No remediation available yet」は誤りで、全て同一メジャー内にパッチ版が出ており、親の許容レンジにも収まります。

| パッケージ | 変更 | 指摘内容 |
|---|---|---|
| nanoid | 3.3.16 → **3.3.18** | 非整数 size での無限ループ |
| fast-uri | 3.1.4 → **3.1.5** | Interpretation Conflict |
| brace-expansion | 1.1.16 → **1.1.18** | 空 `{}` の指数時間展開 DoS |
| | 2.1.2 → **2.1.4** | |
| | 5.0.8 → **5.0.9** | |
| js-yaml | 3.15.0 → **3.15.1** | マージキー連鎖の二次的CPU消費 |
| socket.io-parser | 4.2.6 → **4.2.7** | Improper Check for Exceptional Conditions |

あわせて js-yaml 4系も許容レンジ（`^4.1.0`）内で 4.3.0 → **4.3.1** に再解決されました。これも Snyk 指摘（Inefficient Algorithmic Complexity）の対象です。

## 影響範囲

依存経路はいずれも**ビルドツール**（postcss / stylelint / minimatch / json-schema-ref-parser）で、実行時バンドルには含まれません。`dependencies` に現れるのは Nuxt モジュール自体が prod 依存だからです。

## コメントの訂正2件

codex CLI のレビューで、既存コメントの記述が実態と合っていない点が2つ見つかったので直しました。

1. 「両系統の最新は 1.1.16 / 2.1.2 で修正版が出ていないため上流の対応待ち」→ その後 1.1.18 / 2.1.4 が出ています
2. brace-expansion v5 を強制できない理由を「default export の廃止」と書いていましたが、**壊れ方は入口ごとに違います**（実測）:

   | | 読み込み方 | v5 での壊れ方 |
   |---|---|---|
   | minimatch 9.x | ESM `import expand from` | default export が無く import できない |
   | minimatch 3.x/5.x | CJS `require(...)` | 戻り値が object で関数として呼べない |

   ```
   > require('brace-expansion')
   { EXPANSION_MAX, EXPANSION_MAX_LENGTH, expand }   ← 呼ぶなら .expand(...)
   ```

## 検証

`pnpm install` 後、lockfile に**旧版が1つも残っていない**ことを確認済み。lint のエラー件数は変更前後で同一です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
