### PR TITLE
docs(test): 📝 vitest まわりのコメントを実態に合わせる

### DIFF
--- a/test/ogp-link-cards.spec.ts
+++ b/test/ogp-link-cards.spec.ts
@@ -1,21 +1,28 @@
 // @vitest-environment node
 //
-// node 環境を明示する。vitest.config.ts の既定は jsdom だが、@nuxt/test-utils が
-// Nuxt を部分的に用意する環境で @nuxtjs/mdc を呼ぶと、MDC 内部の composable が
-// Nuxt インスタンスを見つけられず NUXT_E1001 を大量に吐く（結果自体は正しい）。
-// **本体の pnpm ogp:refresh は tsx で Nuxt の外を走る。** node 環境にすれば
-// ノイズが消えるだけでなく、テストと本体の実行条件が揃う。
+// node 環境を明示する。vitest.config.ts の既定は jsdom だが、**本体の
+// pnpm ogp:refresh は tsx で Nuxt も DOM も無い所を走る**ので、実行条件を
+// 揃えておく。
+//
+// **レポーターの `|jsdom|` 表示に惑わされないこと。** 行頭に出るのは
+// プロジェクト既定の環境名で、ファイル単位の上書きは反映されない。
+// 効いているかは `typeof window` で判る（docblock あり → undefined、
+// 外すと object。実測で確認済み）。
 
 /**
  * 抽出ロジックの単体テスト。
  *
  * `scripts/ogp-*.ts` は nuxtation / docustation / private-nuxtation で
- * byte 同一だが、**vitest 基盤があるのはこのリポジトリだけ**（他2つは
- * vite 7 に固定されており vitest 4 が動かない。詳細は nuxtation の
- * tasks/2026-08-08-vite-8-migration.md）。3リポ分の抽出ロジックを
- * ここで代表して検証している。壊すと他2リポも黙って壊れる。
+ * byte 同一で、**この spec と vitest.config.ts も3リポ byte 同一**。
+ * 変更するときは3リポすべてに同じ変更を入れること（同期を強制する
+ * 仕組みは無い）。壊すと3リポとも黙って壊れる。
  *
- * キャッシュ欠落の検出そのものは `pnpm check:ogp-cache` が担当する（3リポ共通）。
+ * **ここで見るのは抽出ロジックだけ。実際の `content/` とキャッシュの
+ * 突き合わせは意図的に持たせていない**（2026-08-09 決定）。それは
+ * `pnpm check:ogp-cache` の担当で、pre-commit と `pnpm build` /
+ * `pnpm generate` の先頭から実行されるため、既に塞がっている。
+ * 同じ検査を vitest 側にも重ねると、キャッシュを更新するたびに直す場所が
+ * 2箇所に増えるだけで、防げる事故は増えない。
  */
 
 import { describe, expect, it } from 'vitest'

--- a/test/ogp-link-cards.spec.ts
+++ b/test/ogp-link-cards.spec.ts
@@ -10,16 +10,17 @@
 // 外すと object。実測で確認済み）。
 
 /**
- * 抽出ロジックの単体テスト。
+ * `scripts/ogp-link-cards.ts` の単体テスト。URL の抽出だけでなく、
+ * `isReservedHost` と `findMissingCacheEntries` の判定もここで固定する。
  *
  * `scripts/ogp-*.ts` は nuxtation / docustation / private-nuxtation で
  * byte 同一で、**この spec と vitest.config.ts も3リポ byte 同一**。
  * 変更するときは3リポすべてに同じ変更を入れること（同期を強制する
  * 仕組みは無い）。壊すと3リポとも黙って壊れる。
  *
- * **ここで見るのは抽出ロジックだけ。実際の `content/` とキャッシュの
- * 突き合わせは意図的に持たせていない**（2026-08-09 決定）。それは
- * `pnpm check:ogp-cache` の担当で、pre-commit と `pnpm build` /
+ * **省いているのは、実際の `content/` とキャッシュを読む統合検査だけ**
+ * （2026-08-09 決定）。判定ロジック自体は上記の通り単体で押さえてある。
+ * 統合検査は `pnpm check:ogp-cache` の担当で、pre-commit と `pnpm build` /
  * `pnpm generate` の先頭から実行されるため、既に塞がっている。
  * 同じ検査を vitest 側にも重ねると、キャッシュを更新するたびに直す場所が
  * 2箇所に増えるだけで、防げる事故は増えない。

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,9 @@
 import { defineVitestConfig } from '@nuxt/test-utils/config'
 
 // テスト基盤の方針:
-// - environment は jsdom。app/composables のテストが document を直接操作するため
-//   （utils.spec.ts の downloadImage は document.createElement を spy する）。
+// - environment は jsdom。DOM を直接触る spec（document.createElement の spy など）が
+//   あるリポジトリに合わせてある。3リポで設定を byte 同一に保つため、spec が
+//   まだ無いリポジトリでも同じ値にしておく。
 // - include は app 配下と test/ 配下。AGENTS.md の規約で **`test/`（単数）が共有の
 //   vitest spec、`tests/`（複数）が Playwright** と分かれている（紛らわしいので注意）。
 //   **既定の include に任せると tests/ の Playwright テストまで拾い、@playwright/test の


### PR DESCRIPTION
docustation に vitest 基盤を導入するにあたり、3リポ byte 同一を保つためのコメント修正です。**設定値・テスト内容に変更はありません。**

本体は [docustation#18](https://github.com/annrie/docustation/pull/18) です。

## 訂正3件

### 1. `vitest.config.ts`：存在しないファイルを根拠にしていた

jsdom を選ぶ理由として `app/composables/utils.spec.ts` を挙げていましたが、これは **private-nuxtation にしか存在しません**。設定ファイルごと複製された際にコメントも一緒に運ばれていました。

```
nuxtation          app/ 配下に spec なし
docustation        app/ 配下に spec なし
private-nuxtation  app/composables/utils.spec.ts ✅
```

リポジトリ固有のファイル名に依存しない書き方へ変更しました。

### 2. `spec` 冒頭：vitest が1リポにしか無かった頃の前提

「**vitest 基盤があるのはこのリポジトリだけ**（他2つは vite 7 に固定されており vitest 4 が動かない）」と書かれていましたが、nuxtation は vite 8 へ移行済み、docustation にも導入されるため、3リポ byte 同一である旨に書き換えました。

### 3. `@vitest-environment node` の根拠が再現しない

NUXT_E1001 の大量出力を理由に挙げていましたが、docblock の有無で **0件 / 0件** と再現しませんでした。実行条件を本体（tsx で Nuxt の外を走る）に揃えるという理由だけを残しています。

あわせて紛らわしい挙動を注意書きに追加しました。レポーターが行頭に出す `|jsdom|` は**プロジェクト既定の環境名**で、ファイル単位の上書きは反映されません。

| | `typeof window` | 実際の環境 |
|---|---|---|
| docblock あり | `undefined` | node ✅ |
| docblock なし | `object` | jsdom |

## 検証

3リポとも `vitest.config.ts` / `test/ogp-link-cards.spec.ts` が byte 同一であることを確認済み。テストは nuxtation 46件 / docustation 45件 / private-nuxtation 49件すべて通過します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
